### PR TITLE
docs: build badges point to master branch results

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p align="center">
   <a href="https://github.com/davelsan/typescript-algorithms/actions?query=workflow%3Abuild">
-    <img alt="Build Status" src="https://github.com/davelsan/typescript-algorithms/workflows/build/badge.svg"/>
+    <img alt="Build Status" src="https://github.com/davelsan/typescript-algorithms/workflows/build/badge.svg?branch=master"/>
   </a>
   <a href="https://codecov.io/gh/davelsan/typescript-algorithms">
     <img alt="Code Coverage" src="https://codecov.io/gh/davelsan/typescript-algorithms/branch/master/graph/badge.svg"/>

--- a/src/compare/symmetric-difference/README.md
+++ b/src/compare/symmetric-difference/README.md
@@ -2,7 +2,7 @@
 
 <p align="center">
   <a href="https://github.com/davelsan/typescript-algorithms/actions?query=workflow%3Asymmetric-difference">
-    <img alt="Build Status" src="https://github.com/davelsan/typescript-algorithms/workflows/symmetric-difference/badge.svg"/>
+    <img alt="Build Status" src="https://github.com/davelsan/typescript-algorithms/workflows/symmetric-difference/badge.svg?branch=master"/>
   </a>
 </p>
 

--- a/src/structure/linked-list/README.md
+++ b/src/structure/linked-list/README.md
@@ -2,7 +2,7 @@
 
 <p align="center">
   <a href="https://github.com/davelsan/typescript-algorithms/actions?query=workflow%3Alinked-list">
-    <img alt="Build Status" src="https://github.com/davelsan/typescript-algorithms/workflows/linked-list/badge.svg"/>
+    <img alt="Build Status" src="https://github.com/davelsan/typescript-algorithms/workflows/linked-list/badge.svg?branch=master"/>
   </a>
 </p>
 


### PR DESCRIPTION
Development branches could erroneously display failed workflows in the project's README files. With this PR, status badges should only display the build status of the `master` branch.

#### Changes in this PR

- `README` build status badges point to the master branch workflow runs.