### PR TITLE
chore: track workflows in the develop branch

### DIFF
--- a/.github/workflows/breadth-first-search.yml
+++ b/.github/workflows/breadth-first-search.yml
@@ -3,6 +3,9 @@ on:
   pull_request:
     branches:
       - develop
+  push:
+    branches:
+      - develop
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,7 @@ name: build
 on:
   push:
     branches:
+      - develop
       - master
 
 jobs:

--- a/.github/workflows/linked-list.yml
+++ b/.github/workflows/linked-list.yml
@@ -3,6 +3,9 @@ on:
   pull_request:
     branches:
       - develop
+  push:
+    branches:
+      - develop
 
 jobs:
   build:

--- a/.github/workflows/symmetric-difference.yml
+++ b/.github/workflows/symmetric-difference.yml
@@ -3,6 +3,9 @@ on:
   pull_request:
     branches:
       - develop
+  push:
+    branches:
+      - develop
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p align="center">
   <a href="https://github.com/davelsan/typescript-algorithms/actions?query=workflow%3Abuild">
-    <img alt="Build Status" src="https://github.com/davelsan/typescript-algorithms/workflows/build/badge.svg?branch=master"/>
+    <img alt="Build Status" src="https://github.com/davelsan/typescript-algorithms/workflows/build/badge.svg?branch=develop"/>
   </a>
   <a href="https://codecov.io/gh/davelsan/typescript-algorithms">
     <img alt="Code Coverage" src="https://codecov.io/gh/davelsan/typescript-algorithms/branch/master/graph/badge.svg"/>

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
     <img alt="Build Status" src="https://github.com/davelsan/typescript-algorithms/workflows/build/badge.svg?branch=develop"/>
   </a>
   <a href="https://codecov.io/gh/davelsan/typescript-algorithms">
-    <img alt="Code Coverage" src="https://codecov.io/gh/davelsan/typescript-algorithms/branch/master/graph/badge.svg"/>
+    <img alt="Code Coverage" src="https://codecov.io/gh/davelsan/typescript-algorithms/branch/develop/graph/badge.svg"/>
   </a>
   <a href="https://github.com/davelsan/typescript-algorithms/blob/master/LICENSE">
     <img alt="License" src="https://img.shields.io/github/license/davelsan/typescript-algorithms"/>

--- a/src/compare/symmetric-difference/README.md
+++ b/src/compare/symmetric-difference/README.md
@@ -2,7 +2,7 @@
 
 <p align="center">
   <a href="https://github.com/davelsan/typescript-algorithms/actions?query=workflow%3Asymmetric-difference">
-    <img alt="Build Status" src="https://github.com/davelsan/typescript-algorithms/workflows/symmetric-difference/badge.svg?branch=master"/>
+    <img alt="Build Status" src="https://github.com/davelsan/typescript-algorithms/workflows/symmetric-difference/badge.svg?branch=develop"/>
   </a>
 </p>
 

--- a/src/search/breadth-first-search/README.md
+++ b/src/search/breadth-first-search/README.md
@@ -2,7 +2,7 @@
 
 <p align="center">
   <a href="https://github.com/davelsan/typescript-algorithms/actions?query=workflow%3Abreadth-first-search">
-    <img alt="Build Status" src="https://github.com/davelsan/typescript-algorithms/workflows/breadth-first-search/badge.svg?branch=master"/>
+    <img alt="Build Status" src="https://github.com/davelsan/typescript-algorithms/workflows/breadth-first-search/badge.svg?branch=develop"/>
   </a>
 </p>
 

--- a/src/structure/linked-list/README.md
+++ b/src/structure/linked-list/README.md
@@ -2,7 +2,7 @@
 
 <p align="center">
   <a href="https://github.com/davelsan/typescript-algorithms/actions?query=workflow%3Alinked-list">
-    <img alt="Build Status" src="https://github.com/davelsan/typescript-algorithms/workflows/linked-list/badge.svg?branch=master"/>
+    <img alt="Build Status" src="https://github.com/davelsan/typescript-algorithms/workflows/linked-list/badge.svg?branch=develop"/>
   </a>
 </p>
 


### PR DESCRIPTION
Changes to workflow and README files, so that build badges track the develop branch.

#### Changes in this PR

- `build` runs on PR to `develop`
- `breadth-first-search`, `linked-list`, and `symmetric-difference` run on push and PR to `develop`
- updated all `README` badges with the appropriate `develop` href